### PR TITLE
mark GSI images with type on release page

### DIFF
--- a/releases.html
+++ b/releases.html
@@ -68,7 +68,7 @@
           <a href="https://dweb.link/ipfs/bafybeifpj2ti6cyb2v5syyvtzyspl6jkp3n225rychirwv5otpc6wjbxzq">Pixel 3a (sargo)</a>
         </li>
         <li>
-          <a href="https://dweb.link/ipfs/bafybeicwgek5422glorxhshft555a6ogba4cq4dlnzjq5upgsd4cd563aa">Generic System Image</a>
+          <a href="https://dweb.link/ipfs/bafybeicwgek5422glorxhshft555a6ogba4cq4dlnzjq5upgsd4cd563aa">Generic System Image (A/B arm64)</a>
         </li>
       </ul>
 
@@ -127,7 +127,7 @@
         <li>
           <a
             href="https://dweb.link/ipfs/bafybeicm46teebtmw2be4zzrn3lben7ao27sxwuk6fwbdaympc54lwzfjy"
-            >Generic System Image</a
+            >Generic System Image (A/B arm64)</a
           >
         </li>
       </ul>
@@ -162,7 +162,7 @@
         <li>
           <a
             href="https://dweb.link/ipfs/bafybeic2yvlxq73zkglnkbqqfphlqqwjcpnchs2jmryj3hrnu6qon6bbtm"
-            >Generic System Image</a
+            >Generic System Image (A/B arm64)</a
           >
         </li>
       </ul>
@@ -194,7 +194,7 @@
         <li>
           <a
             href="https://bafybeifwxgh4aysob2fwdju4d74rkwbieuei7xb2guy7xtbmkkjafqqbwa.ipfs.dweb.link/gsi.tar.xz"
-            >Generic System Image</a
+            >Generic System Image (A/B arm64)</a
           >
         </li>
       </ul>
@@ -225,7 +225,7 @@
         <li>
           <a
             href="https://bafybeihmdu62yeexbekl24bq5oynuuvb2q6ope2vvwnmzubnqbvyy37ap4.ipfs.dweb.link/gsi.tar.xz"
-            >Generic System Image</a
+            >Generic System Image (A/B arm64)</a
           >
         </li>
       </ul>
@@ -254,7 +254,7 @@
         <li>
           <a
             href="https://bafybeibugvpz5kvzrbo5fneqa622pmykpzyknxxphukbpjtziqzjycyusu.ipfs.dweb.link/gsi.tar.xz"
-            >Generic System Image</a
+            >Generic System Image (A/B arm64)</a
           >
         </li>
       </ul>


### PR DESCRIPTION
s/Generic System Image/Generic System Image (A/B arm64)/ to make it clearer what base is needed